### PR TITLE
Get database container IP from environment variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,6 @@ FROM openshift/ruby-20-centos
 # Install mysql client and gems to connect app to database.
 USER root
 RUN yum install -y mysql && gem install sinatra activerecord mysql2 --no-ri --no-rdoc
-# FIXME: This should be the DATABASE_SERVICE_HOST environment variable,
-# but the container doesn't know how to resolve the hostname now.
-# It represents the database host, in case the app should connect to one.
-ENV DATABASE_SERVICE_IP_ADDR 172.17.42.1
 
 USER ruby
 ADD app.rb /tmp/app.rb

--- a/app.rb
+++ b/app.rb
@@ -4,9 +4,9 @@ require 'sinatra'
 set :bind, '0.0.0.0'
 set :port, 8080
 
-if not ("#{ENV["MYSQL_DATABASE"]}".blank? || "#{ENV["MYSQL_ROOT_PASSWORD"]}".blank? || "#{ENV["DATABASE_SERVICE_PORT"]}".blank?)
+if not ("#{ENV["MYSQL_DATABASE"]}".blank? || "#{ENV["MYSQL_ROOT_PASSWORD"]}".blank? || "#{ENV["DATABASE_SERVICE_HOST"]}".blank?)
 
-  while  %x"mysqladmin ping -h #{ENV["DATABASE_SERVICE_IP_ADDR"]} --port=#{ENV["DATABASE_SERVICE_PORT"]} -uroot -p#{ENV["MYSQL_ROOT_PASSWORD"]}".strip != "mysqld is alive"
+  while  %x"mysqladmin ping -h #{ENV["DATABASE_SERVICE_HOST"]} --port=#{ENV["DATABASE_SERVICE_PORT"]} -uroot -p#{ENV["MYSQL_ROOT_PASSWORD"]}".strip != "mysqld is alive"
     puts "Waiting for database connection...\n"
     sleep 1
   end


### PR DESCRIPTION
We now allocate an IP for each container, so the database container has an IP which we can use in the app container to establish the connection.

Is not yet tested, but it should work.
