### PR TITLE
Updating base image name to new ruby-20-centos7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openshift/ruby-20-centos
+FROM openshift/ruby-20-centos7
 
 RUN gem install sinatra sinatra-activerecord mysql2 --no-ri --no-rdoc
 


### PR DESCRIPTION
This is a part of work on https://trello.com/c/UJG1mPZf/364-3-v3-ruby-image-image-beta2
Also last step before we cant get rid of the ruby-20-centos repository