### PR TITLE
Allow the application to start up even if the database service env var i...

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -27,7 +27,7 @@ end
 configure do
   puts "Run app..."
 
-  unless ENV["DATABASE_SERVICE_HOST"].nil?
+  unless ENV["DATABASE_SERVICE_HOST"].nil? && ENV["DATABASE_TEST_SERVICE_HOST"].nil?
     configure_database
   end
 end

--- a/app.rb
+++ b/app.rb
@@ -5,9 +5,7 @@ require_relative 'models'
 set :bind, '0.0.0.0'
 set :port, 8080
 
-configure do
-  puts "Run app..."
-
+def configure_database
   if ENV['RACK_ENV']=="production"
     while !self.connect_to_database_prod
       puts "Connecting to production database (#{ENV['DATABASE_SERVICE_HOST']})...\n"
@@ -26,8 +24,16 @@ configure do
   %x"rake db:migrate"
 end
 
+configure do
+  puts "Run app..."
+
+  unless ENV["DATABASE_SERVICE_HOST"].nil?
+    configure_database
+  end
+end
+
 get '/' do
-  File.read('main.html')
+  erb :main
 end
 
 get '/keys' do

--- a/views/main.erb
+++ b/views/main.erb
@@ -18,7 +18,7 @@
     <h1> Welcome to an OpenShift v3 Demo App! </h1>
   </div>
 
-  <% if ENV["DATABASE_SERVICE_HOST"].nil? %>
+  <% if ENV["DATABASE_SERVICE_HOST"].nil? && ENV["DATABASE_TEST_SERVICE_HOST"].nil? %>
   <div class="container" align=center>
     <h3>(It looks like the database isn't running.  This isn't going to be much fun.)</h3>
   </div>

--- a/views/main.erb
+++ b/views/main.erb
@@ -18,6 +18,11 @@
     <h1> Welcome to an OpenShift v3 Demo App! </h1>
   </div>
 
+  <% if ENV["DATABASE_SERVICE_HOST"].nil? %>
+  <div class="container" align=center>
+    <h3>(It looks like the database isn't running.  This isn't going to be much fun.)</h3>
+  </div>
+  <% else %>
   <div class="container">
     <h3> Get, edit or delete key-value pairs, for fun. </h3>
     </br>
@@ -43,6 +48,7 @@
       </div>
     </form>
   </div>
+  <% end %>
 </body>
 
 <script type="text/javascript">


### PR DESCRIPTION
...s missing

This is an approach at what @thoraxe wanted.  I tested a deployment with and without the database and it worked as expected.  I'm not exactly sure how the database service will be added after the fact but this should be enough to unblock the beta2 testing.  Once we've settled on the approach we can merge this (or something similar) in.