### PR TITLE
Fix Ruby 2.2 compatibility

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GEM
     arel (5.0.1.20140414130214)
     builder (3.2.2)
     i18n (0.6.11)
-    json (1.8.1)
+    json (1.8.3)
     minitest (5.4.2)
     mysql2 (0.3.16)
     rack (1.5.2)


### PR DESCRIPTION
json-1.8.1 fails to build with Ruby 2.2:

~~~
$ gem install json -v 1.8.1
Fetching: json-1.8.1.gem (100%)
Building native extensions.  This could take a while...
ERROR:  Error installing json:
	ERROR: Failed to build gem native extension.

    /opt/rh/rh-ruby22/root/usr/bin/ruby -r ./siteconf20150729-19319-v9hnj0.rb extconf.rb
creating Makefile

make "DESTDIR=" clean
rm -f 
rm -f generator.so  *.o  *.bak mkmf.log .*.time

make "DESTDIR="
gcc -I. -I/opt/rh/rh-ruby22/root/usr/include -I/opt/rh/rh-ruby22/root/usr/include/ruby/backward -I/opt/rh/rh-ruby22/root/usr/include -I. -DJSON_GENERATOR    -fPIC -O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -mtune=generic -fPIC -O3 -Wall -O0 -ggdb -m64 -o generator.o -c generator.c
In file included from /usr/include/stdio.h:27:0,
                 from /opt/rh/rh-ruby22/root/usr/include/ruby/defines.h:26,
                 from /opt/rh/rh-ruby22/root/usr/include/ruby/ruby.h:29,
                 from /opt/rh/rh-ruby22/root/usr/include/ruby.h:33,
                 from ../fbuffer/fbuffer.h:5,
                 from generator.c:1:
/usr/include/features.h:330:4: warning: #warning _FORTIFY_SOURCE requires compiling with optimization (-O) [-Wcpp]
 #  warning _FORTIFY_SOURCE requires compiling with optimization (-O)
    ^
In file included from generator.c:1:0:
../fbuffer/fbuffer.h: In function 'fbuffer_to_s':
../fbuffer/fbuffer.h:175:47: error: macro "rb_str_new" requires 2 arguments, but only 1 given
     VALUE result = rb_str_new(FBUFFER_PAIR(fb));
                                               ^
../fbuffer/fbuffer.h:175:20: warning: initialization makes integer from pointer without a cast [enabled by default]
     VALUE result = rb_str_new(FBUFFER_PAIR(fb));
                    ^
make: *** [generator.o] Error 1

make failed, exit code 2

Gem files will remain installed in /builddir/.gem/ruby/gems/json-1.8.1 for inspection.
Results logged to /builddir/.gem/ruby/extensions/x86_64-linux/json-1.8.1/gem_make.out
~~~

While json-1.8.3 builds just fine.