### PR TITLE
Fix for Ruby 2.4 compatibility

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GEM
     arel (5.0.1.20140414130214)
     builder (3.2.2)
     i18n (0.6.11)
-    json (1.8.3)
+    json (1.8.6)
     minitest (5.4.2)
     mysql2 (0.3.16)
     rack (1.5.2)


### PR DESCRIPTION
Hello,
I want to use `json-1.8.6` for Ruby 2.4.0 compatibility instead of `json-1.8.3`.
Can you merge this PR? Thanks.

```
$ s2i build --force-pull=false . local-test-image local-test-image-testapp
...
current directory:
/opt/app-root/src/bundle/ruby/2.4.0/gems/json-1.8.3/ext/json/ext/generator
make "DESTDIR=" clean
rm -f
rm -f generator.so  *.o  *.bak mkmf.log .*.time

current directory:
/opt/app-root/src/bundle/ruby/2.4.0/gems/json-1.8.3/ext/json/ext/generator
make "DESTDIR="
gcc -I. -I/opt/rh/rh-ruby24/root/usr/include
-I/opt/rh/rh-ruby24/root/usr/include/ruby/backward
-I/opt/rh/rh-ruby24/root/usr/include -I. -DJSON_GENERATOR    -fPIC -O2 -g -pipe
-Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong
--param=ssp-buffer-size=4 -grecord-gcc-switches -mtune=generic -fPIC -m64 -o
generator.o -c generator.c
generator.c: In function 'generate_json':
generator.c:861:25: error: 'rb_cFixnum' undeclared (first use in this function)
} else if (klass == rb_cFixnum) {
^
generator.c:861:25: note: each undeclared identifier is reported only once for
each function it appears in
generator.c:863:25: error: 'rb_cBignum' undeclared (first use in this function)
} else if (klass == rb_cBignum) {
^
make: *** [generator.o] Error 1
```