### PR TITLE
Start CI, fixing an error on Ruby 2.5.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: ruby
+sudo: false
+rvm:
+  - 2.2
+  - 2.3
+  - 2.4
+  - 2.5
+before_install:
+  - cp -p Gemfile.lock Gemfile.lock.org
+script:
+  # Gemfile.lock should not include BUNDLED WITH part
+  # to prevent old version Bundler to update the file.
+  # https://github.com/openshift/ruby-hello-world/pull/64#issuecomment-363731682
+  - |
+    if grep '^BUNDLED WITH' Gemfile.lock; then
+      false
+    else
+      true
+    fi
+  # Check Gemfile.lock is not edited because that causes an error
+  # with openshift cluster.
+  - diff Gemfile.lock.org Gemfile.lock
+  - bundle exec rake test

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,4 +1,4 @@
-<% # Handle old behaviour of official mysql image %>
+<%# Handle old behaviour of official mysql image %>
 <% user = ENV.key?("MYSQL_ROOT_PASSWORD") ? "root" : ENV["MYSQL_USER"] %>
 <% password = ENV.key?("MYSQL_ROOT_PASSWORD") ? ENV["MYSQL_ROOT_PASSWORD"] : ENV["MYSQL_PASSWORD"] %>
 development:


### PR DESCRIPTION
No change for `Gemfile.lock`.

* Update a template file for Ruby 2.5.0 ERB syntax.
* Add Travis CI.

According to latest revert [1] by an error on openshift/origin [2], the reason looks related to new version of `mysql2` and `activerecord`.

So, let's do a baby step.

Ideally one day, it is good to add unit test cases for `run.sh` and to be run by `openshift/origin`, to this repository's CI.
What I want is to run `run.sh` on Ruby 2.5.

Running `run.sh` on Ruby 2.5, that shows warnings like this.

```
/opt/app-root/src/bundle/ruby/2.5.0/gems/sinatra-1.4.5/lib/sinatra/base.rb:1217: warning: constant ::Fixnum is deprecated
```

But I think that this PR is still okay for the first step.

[1] https://github.com/openshift/ruby-hello-world/pull/67
[2] https://github.com/openshift/origin/issues/18522#issuecomment-364054365
