### PR TITLE
Use ubi8/ruby-27

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
-FROM quay.io/centos7/ruby-27-centos7
+FROM registry.access.redhat.com/ubi8/ruby-27
 USER default
 EXPOSE 8080
 ENV RACK_ENV production
 ENV RAILS_ENV production
 COPY . /opt/app-root/src/
 ENV GEM_HOME ~/.gem
-RUN scl enable rh-ruby27 "bundle install"
-CMD ["scl", "enable", "rh-ruby27", "./run.sh"]
+RUN bundle install
+CMD ["./run.sh"]
 
 USER root
 RUN chmod og+rw /opt/app-root/src/db


### PR DESCRIPTION
This is necessary for the build tests on other architectures, as the
centos S2I images are x86_64 only.﻿
