### PR TITLE
Switch base image registry to quay.io

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos/ruby-27-centos7
+FROM quay.io/centos7/ruby-27-centos7
 USER default
 EXPOSE 8080
 ENV RACK_ENV production


### PR DESCRIPTION
DockerHub imposes pull limits on images causing issues with building
this application. This commit switches it to use base image from
quay.io.