### PR TITLE
Refresh Gemfile{,.lock} for Ruby 3.3.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gem 'sinatra', '2.1.0'
 gem 'sinatra-activerecord', '2.0.22'
-gem 'mysql2', '0.5.3'
+gem 'mysql2', '0.5.5'
 gem 'rake', '13.0.3'
 gem 'minitest', '5.14.4'
 gem 'i18n', '1.8.9'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,13 +12,13 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
-    concurrent-ruby (1.2.2)
+    concurrent-ruby (1.2.3)
     i18n (1.8.9)
       concurrent-ruby (~> 1.0)
     minitest (5.14.4)
     mustermann (1.1.2)
       ruby2_keywords (~> 0.0.1)
-    mysql2 (0.5.3)
+    mysql2 (0.5.5)
     rack (2.2.8)
     rack-protection (2.1.0)
       rack
@@ -32,11 +32,11 @@ GEM
     sinatra-activerecord (2.0.22)
       activerecord (>= 4.1)
       sinatra (>= 1.0)
-    tilt (2.2.0)
+    tilt (2.3.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     webrick (1.7.0)
-    zeitwerk (2.6.11)
+    zeitwerk (2.6.13)
 
 PLATFORMS
   ruby
@@ -44,7 +44,7 @@ PLATFORMS
 DEPENDENCIES
   i18n (= 1.8.9)
   minitest (= 5.14.4)
-  mysql2 (= 0.5.3)
+  mysql2 (= 0.5.5)
   rake (= 13.0.3)
   sinatra (= 2.1.0)
   sinatra-activerecord (= 2.0.22)


### PR DESCRIPTION
APIs removed between Ruby 3.1 and 3.3 result in
mysql2 build failures due to missing C APIs in new Ruby, such as "taintedness" and "safeness" functions.

Update to gem mysql2 0.5.5 that no longer fails
to compile with Ruby 3.3.

Ruby 2.5 keeps building OK.

2.5 container build log: 
https://gist.github.com/jackorp/d6f10a3b9f8430a7951244a041657129
3.3 container build log:
https://gist.github.com/jackorp/8fae99f431a8da85bc06f773368e30e9