### PR TITLE
Fix app.rb for Ruby 3.3.

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -5,6 +5,8 @@ require_relative 'models'
 set :bind, '0.0.0.0'
 set :port, 8080
 
+set :app_file, __FILE__
+
 def configure_database
   if ENV['RACK_ENV']=="production"
     while !self.connect_to_database_prod


### PR DESCRIPTION
Since Ruby 3.3 [0], bundled_gems.rb intercepts `require` calls with bundler. Under sinatra, this causes issues. Sinatra searches for the `app.rb` style files in the call stack. Once found, sinatra uses that file as a project's root. From there it searches for other default directories such `views` and other.

Example of such failure from logs:
~~~
2024-05-14 12:22:14 - Errno::ENOENT - No such file or directory @ rb_sysopen - /usr/share/ruby/views/main.erb ~~~
This error appears only once a request was made to the part of code that relies on the relative default paths, such as the './views' for the erb templates.

This was fixed with Sinatra 3.2.0[1], but to keep compatibility with Ruby 2.5, Sinatra version 2.* should remain for a while as Sinatra 3.* restricts minimum Ruby version to Ruby 2.6.

We work around it ourselves by overriding the :app_file setting in `app.rb` file to `__FILE__` which will fix the rest of paths.

[0] https://github.com/ruby/ruby/commit/214f6d6598be8437284dede9eb9a041a3ebfb24e
[1] https://github.com/sinatra/sinatra/blob/main/CHANGELOG.md#320--2023-12-29

- - -

Problem found in tests for s2i ruby container: https://github.com/sclorg/s2i-ruby-container/pull/507#issuecomment-2109657833 .

This commit was tested with Ruby 2.5, 3.0, 3.1 and 3.3. Simple GET request that was failing as outlined above is now passing:
For 2.5 to 3.1 the `registry.access.redhat.com/ubi8/ruby-$VERSION` container namespace was used. For 3.3, custom `quay.io/s2i-ruby/c9s:3.3-experimental` was used. Functionality is the same. Container was run as: `podman run -p8080:8080 -it --rm localhost/test-hello:latest /usr/libexec/s2i/run`, Dockerfile was slightly adjusted to keep more in-sync with what we were seeing in our tests.

Relevant excerpts from logs:
2.5:
```
[2024-05-14 13:17:58] INFO  WEBrick 1.7.0
[2024-05-14 13:17:58] INFO  ruby 2.5.9 (2021-04-05) [x86_64-linux]
[2024-05-14 13:17:58] INFO  WEBrick::HTTPServer#start: pid=1 port=8080
/opt/app-root/src/.gem/gems/sinatra-2.1.0/lib/sinatra/base.rb:922: warning: constant Tilt::Cache is deprecated
Servicing index request...
127.0.0.1 - - [14/May/2024:13:18:00 +0000] "GET / HTTP/1.1" 200 2478 0.0072
^C[2024-05-14 13:18:05] INFO  going to shutdown ...
[2024-05-14 13:18:05] INFO  WEBrick::HTTPServer#start done.
```
3.0:
```
[2024-05-14 13:27:49] INFO  WEBrick 1.7.0
[2024-05-14 13:27:49] INFO  ruby 3.0.4 (2022-04-12) [x86_64-linux]
[2024-05-14 13:27:49] INFO  WEBrick::HTTPServer#start: pid=1 port=8080
Servicing index request...
127.0.0.1 - - [14/May/2024:13:27:52 +0000] "GET / HTTP/1.1" 200 2478 0.0076
^C[2024-05-14 13:27:58] INFO  going to shutdown ...
[2024-05-14 13:27:58] INFO  WEBrick::HTTPServer#start done.
```
3.1:
```
[2024-05-14 13:29:07] INFO  WEBrick 1.7.0
[2024-05-14 13:29:07] INFO  ruby 3.1.4 (2023-03-30) [x86_64-linux]
[2024-05-14 13:29:07] INFO  WEBrick::HTTPServer#start: pid=1 port=8080
Servicing index request...
127.0.0.1 - - [14/May/2024:13:29:07 +0000] "GET / HTTP/1.1" 200 2478 0.0083
^C[2024-05-14 13:29:09] INFO  going to shutdown ...
[2024-05-14 13:29:09] INFO  WEBrick::HTTPServer#start done.
```
3.3:
```
[2024-05-14 13:30:03] INFO  WEBrick 1.7.0
[2024-05-14 13:30:03] INFO  ruby 3.3.0 (2023-12-25) [x86_64-linux]
[2024-05-14 13:30:03] INFO  WEBrick::HTTPServer#start: pid=1 port=8080
Servicing index request...
127.0.0.1 - - [14/May/2024:13:30:05 +0000] "GET / HTTP/1.1" 200 2478 0.0162
^C[2024-05-14 13:30:06] INFO  going to shutdown ...
[2024-05-14 13:30:06] INFO  WEBrick::HTTPServer#start done.
```