### PR TITLE
Supply BUNDLE_FROZEN=true to prevent Gemfile.lock modifications.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ ENV RACK_ENV production
 ENV RAILS_ENV production
 COPY . /opt/app-root/src/
 ENV GEM_HOME ~/.gem
+ENV BUNDLE_FROZEN true
 RUN bundle install
 CMD ["./run.sh"]
 


### PR DESCRIPTION
In Ruby 3.3, bundler attempts to update Gemfile.lock metadata on bundle install unless --frozen is used. Since the app is effectively read-only in the current dockerfile as the owner is not changed, attempts to update metadata of the file will be met with "permission denied" errors.

Supplying BUNDLE_FROZEN to ENV is the same as setting the --frozen on CLI, and prevents bundler from updating Gemfile.lock at all and treat it only read-only.

Additionally, to make sure we aren't using new CLI or approaches that might be incompatible in future or past rubies, we supply an ENV variable that gets read by bundler shipped with Ruby 3.3.

This can be met, using Dockerfile before this commit and running the container build.
```
$ bundle install
<...snip...>
Installing sinatra-activerecord 2.0.22
There was an error while trying to write to `/opt/app-root/src/Gemfile.lock`. It
is likely that you need to grant write permissions for that path.
```

With `ubi8/ruby-33` and `ubi9/ruby-33`, if using this repo in OpenShift using `git` as the `type` for `source`, the build will fail. This Dockerfile does not chown the sources after COPY, therefore the source are read-only, with Ruby 3.3 bundler attempts to update Gemfile.lock metadata it fails, failing the build.

Example BuildConfig where the issue was found:
```yaml
- kind: BuildConfig
  apiVersion: build.openshift.io/v1
  metadata:
    name: sample-docker-build-noproxy
    creationTimestamp:
  spec:
    triggers:
    - type: imageChange
      imageChange: {}
    source:
      type: Git
      git:
        uri: https://github.com/openshift/ruby-hello-world.git
        httpProxy: http://gituser:password@proxy1.com/
        httpsProxy: https://gituser:password@proxy2.com/
        noProxy: github.com
    strategy:
      type: Docker
      dockerStrategy:
        from:
          kind: DockerImage
          name: openshift/ruby:3.3-ubi8
        env:
        - name: SOME_HTTP_PROXY
          value: https://envuser:password@proxy3.com/
        - name: SOME_HTTPS_PROXY
          value: https://envuser:password@proxy4.com/
        - name: "BUILD_LOGLEVEL"
```

build would fail with

```
There was an error while trying to write to `/opt/app-root/src/Gemfile.lock`. It is likely that you need to grant write permissions for that path.
```

With this PR the build now passes.